### PR TITLE
orders model

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,11 @@
+class Order < ApplicationRecord
+  belongs_to :warehouse
+  belongs_to :product
+
+  validates :warehouse, presence: true
+  validates :product, presence: true
+  validates :quantity, presence: true
+  validates :quantity, numericality: {greater_than: 0}
+
+  # validates quantity is gt 0
+end

--- a/db/migrate/20240504142714_create_orders.rb
+++ b/db/migrate/20240504142714_create_orders.rb
@@ -1,0 +1,11 @@
+class CreateOrders < ActiveRecord::Migration[7.0]
+  def change
+    create_table :orders do |t|
+      t.decimal :quantity, null: false
+      t.boolean :dispatched, null: false, default: false
+      t.belongs_to :warehouse, null: false, foreign_key: true
+      t.belongs_to :product, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_16_091933) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_04_142714) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "orders", force: :cascade do |t|
+    t.decimal "quantity", null: false
+    t.boolean "dispatched", default: false, null: false
+    t.bigint "warehouse_id", null: false
+    t.bigint "product_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["product_id"], name: "index_orders_on_product_id"
+    t.index ["warehouse_id"], name: "index_orders_on_warehouse_id"
+  end
 
   create_table "products", force: :cascade do |t|
     t.string "code"
@@ -37,6 +48,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_16_091933) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "orders", "products"
+  add_foreign_key "orders", "warehouses"
   add_foreign_key "stocks", "products"
   add_foreign_key "stocks", "warehouses"
 end

--- a/test/models/order_test.rb
+++ b/test/models/order_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class OrderTest < ActiveSupport::TestCase
+  warehouse = Warehouse.find_by(code:'ABC123')
+  product = Product.find_by(code:'ABC123')
+  test "creates order with despatch default false" do
+    order = Order.create(warehouse:warehouse, product:product, quantity: 4)
+    assert_equal order.dispatched, false
+  end
+
+  test "order requires warehouse" do
+    order = Order.new(product:product, quantity: 4)
+    assert_not order.save
+  end
+
+  test "order requires product" do
+    order = Order.new(warehouse:warehouse, quantity: 4)
+    assert_not order.save
+  end
+
+  test "order requires quantity" do
+    order = Order.new(warehouse:warehouse, product: product)
+    assert_not order.save
+  end
+
+  test "quantity must be greater than zero" do
+    order = Order.create(warehouse:warehouse, product:product, quantity: 0)
+    assert_not order.save
+  end
+
+  test "quantity must be positive" do
+    order = Order.create(warehouse:warehouse, product:product, quantity: -2)
+    assert_not order.save
+  end
+
+end


### PR DESCRIPTION
Adds an orders model.

Added as a distinct PR because both the endpoints for submitting an order and getting stick levels will need it. 

I've used a boolean for the dispatch status as opposed to an enum because, in this case, it's a binary state. I acknowledge that the state list could expand however a boolean is simpler for now. Should a third state be added then that would probably be the time to change it to an enum. 

I'm also a little confused at this point about the decision to use a decimal rather than an integer for stock quantities. Presumably a warehouse will not store a fraction of an item? However, at this point I'm going with it and not explicitly validating for integers. 