### PR TITLE
Separate Stock Balance

### DIFF
--- a/app/controllers/stocks_controller.rb
+++ b/app/controllers/stocks_controller.rb
@@ -31,9 +31,13 @@ class StocksController < ApplicationController
     rescue ActiveRecord::RecordNotFound
       return render json: { error: "product #{product_id} does not exist" }, status: 412
     end
-
-    stock = Stock.find_or_create_by(warehouse_id:, product_id:)
-    stock.update(quantity: (stock.quantity.to_f + params['quantity'].to_i))
+    begin
+      pp(params['quantity'])
+      quantity = Integer(params['quantity'])
+    rescue ArgumentError
+      return render json: { error: "Quantity must be an integer" }, status: 400
+    end
+    Stock.intake(warehouse_id, product_id, quantity)
     render json: :success
   end
 

--- a/app/models/concerns/pending_orders_concern.rb
+++ b/app/models/concerns/pending_orders_concern.rb
@@ -5,7 +5,7 @@ module PendingOrdersConcern
 
   class_methods do
     def pending(warehouse_id, product_id)
-      Order.where(warehouse_id:, product_id:, dispatched: false).sum(:quantity)
+      Stock.where(warehouse_id:, product_id:, reserved: true).count
     end
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -3,6 +3,7 @@
 class Order < ApplicationRecord
   belongs_to :warehouse
   belongs_to :product
+  has_many :stocks
 
   validates :warehouse, presence: true
   validates :product, presence: true

--- a/app/models/stock.rb
+++ b/app/models/stock.rb
@@ -3,6 +3,7 @@
 class Stock < ApplicationRecord
   belongs_to :warehouse
   belongs_to :product
+  belongs_to :order, optional: true
 
   include StockLevelsConcern
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
   resources :stocks, only: %i[index]
 
   put '/stocks/:warehouse_id/:product_id/:quantity', to: 'stocks#intake'
+
+  put '/orders/:warehouse_id/:product_id/:quantity', to: 'orders#place'
   resources :warehouses
   resources :products
 end

--- a/db/migrate/20230216091933_create_stocks.rb
+++ b/db/migrate/20230216091933_create_stocks.rb
@@ -3,7 +3,8 @@
 class CreateStocks < ActiveRecord::Migration[7.0]
   def change
     create_table :stocks do |t|
-      t.decimal :quantity
+      t.boolean :reserved, null: false, default:false
+
       t.belongs_to :warehouse, null: false, foreign_key: true
       t.belongs_to :product, null: false, foreign_key: true
 

--- a/db/migrate/20240506161734_add_orders_to_stocks.rb
+++ b/db/migrate/20240506161734_add_orders_to_stocks.rb
@@ -1,0 +1,5 @@
+class AddOrdersToStocks < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :stocks, :order, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,46 +10,48 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 20_240_504_142_714) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_06_161734) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+  enable_extension "plpgsql"
 
-  create_table 'orders', force: :cascade do |t|
-    t.decimal 'quantity', null: false
-    t.boolean 'dispatched', default: false, null: false
-    t.bigint 'warehouse_id', null: false
-    t.bigint 'product_id', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['product_id'], name: 'index_orders_on_product_id'
-    t.index ['warehouse_id'], name: 'index_orders_on_warehouse_id'
+  create_table "orders", force: :cascade do |t|
+    t.decimal "quantity", null: false
+    t.boolean "dispatched", default: false, null: false
+    t.bigint "warehouse_id", null: false
+    t.bigint "product_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["product_id"], name: "index_orders_on_product_id"
+    t.index ["warehouse_id"], name: "index_orders_on_warehouse_id"
   end
 
-  create_table 'products', force: :cascade do |t|
-    t.string 'code'
-    t.string 'description'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "products", force: :cascade do |t|
+    t.string "code"
+    t.string "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'stocks', force: :cascade do |t|
-    t.decimal 'quantity'
-    t.bigint 'warehouse_id', null: false
-    t.bigint 'product_id', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['product_id'], name: 'index_stocks_on_product_id'
-    t.index ['warehouse_id'], name: 'index_stocks_on_warehouse_id'
+  create_table "stocks", force: :cascade do |t|
+    t.boolean "reserved", default: false, null: false
+    t.bigint "warehouse_id", null: false
+    t.bigint "product_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "order_id"
+    t.index ["order_id"], name: "index_stocks_on_order_id"
+    t.index ["product_id"], name: "index_stocks_on_product_id"
+    t.index ["warehouse_id"], name: "index_stocks_on_warehouse_id"
   end
 
-  create_table 'warehouses', force: :cascade do |t|
-    t.string 'code'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "warehouses", force: :cascade do |t|
+    t.string "code"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  add_foreign_key 'orders', 'products'
-  add_foreign_key 'orders', 'warehouses'
-  add_foreign_key 'stocks', 'products'
-  add_foreign_key 'stocks', 'warehouses'
+  add_foreign_key "orders", "products"
+  add_foreign_key "orders", "warehouses"
+  add_foreign_key "stocks", "products"
+  add_foreign_key "stocks", "warehouses"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,7 +15,13 @@ Product.find_or_create_by(description: 'Thingamyjigs', code: 'TMYG')
 warehouse = Warehouse.find_or_create_by(code: 'ABC123')
 Warehouse.find_or_create_by(code: 'XYZ789')
 
-Stock.find_or_create_by(product: widgets, warehouse:, quantity: 100)
+100.times do
+  Stock.create(product: widgets, warehouse:)
+end
 
 Order.find_or_create_by(product: widgets, warehouse:, quantity: 15, dispatched: true)
-Order.find_or_create_by(product: widgets, warehouse:, quantity: 12, dispatched: false)
+order2 = Order.find_or_create_by(product: widgets, warehouse:, quantity: 12, dispatched: false)
+
+12.times do
+  Stock.create(product: widgets, warehouse:, order_id: order2.id, reserved: true)
+end

--- a/docs/api/order.md
+++ b/docs/api/order.md
@@ -2,7 +2,7 @@
 
 ## Place
 ### Request
-`PUT /order/:warehouse_id:/:product_id/:quantity`
+`PUT /orders/:warehouse_id:/:product_id/:quantity`
 
 ### Responses
 

--- a/docs/api/stocks.md
+++ b/docs/api/stocks.md
@@ -12,7 +12,8 @@
 |success| 200||
 |server error| 500||
 |warehouse not found|412| The spefified warehouse does not exist|
-|product not found| 412 | The ordered product does not exist in the inventory for the speficied warehouse.
+|product not found| 412 | The ordered product does not exist in the inventory for the speficied warehouse.|
+|Non integer quantitiy| 400| Quantity must be an integer|
 
 ## Levels
 
@@ -23,5 +24,5 @@
 
 |type|code|data|description|
 |-|-|-|-|
-|success| 200|`{[warehouse_code: [{'product_code': ABC123, 'total': 15, 'reserved': 5}]]}`|'total' is the number of items currently in stock including 'reserved' items. <br><br>'reserved' is the number of items required to fulfill existing orders|
+|success| 200|`{warehouse_code: [{'product_code': ABC123, 'total': 15, 'reserved': 5}]}`|'total' is the number of items currently in stock including 'reserved' items. <br><br>'reserved' is the number of items required to fulfill existing orders|
 |server error| 500|||

--- a/test/concerns/stock_levels_test.rb
+++ b/test/concerns/stock_levels_test.rb
@@ -13,7 +13,10 @@ class StockLevelsTest < ActiveSupport::TestCase
     inventory = StockLevelsDummy.stock_levels
 
     assert_equal inventory,
-                 [{ 'ABC123' => [{ product_code: 'ABC123', total: 10, reserved: 4 }] },
-                  { 'XYZ789' => [{ product_code: 'DEF456', total: 8, reserved: 0 }] }]
+                 {
+                   'ABC123' => [{ product_code: 'DEF456', total: 1, reserved: 0 },
+                                { product_code: 'ABC123', total: 5,
+                                  reserved: 4 }], 'XYZ789' => [{ product_code: 'DEF456', total: 1, reserved: 0 }]
+                 }
   end
 end

--- a/test/controllers/stocks/stock_levels_test.rb
+++ b/test/controllers/stocks/stock_levels_test.rb
@@ -7,7 +7,11 @@ class StockLevelsTest < ActionDispatch::IntegrationTest
     get stocks_path
 
     assert_equal 200, status
-    assert_equal body, [{ 'ABC123' => [{ product_code: 'ABC123', total: '10.0', reserved: '4.0' }] },
-                        { 'XYZ789' => [{ product_code: 'DEF456', total: '8.0', reserved: '0.0' }] }].to_json
+    assert_equal body,
+                 {
+                   'ABC123' => [{ product_code: 'DEF456', total: 1, reserved: 0 },
+                                { product_code: 'ABC123', total: 5,
+                                  reserved: 4 }], 'XYZ789' => [{ product_code: 'DEF456', total: 1, reserved: 0 }]
+                 }.to_json
   end
 end

--- a/test/controllers/stocks/update_stocks_test.rb
+++ b/test/controllers/stocks/update_stocks_test.rb
@@ -11,9 +11,9 @@ class UpdateStocksTest < ActionDispatch::IntegrationTest
 
     assert_equal 200, status
 
-    stock = Stock.find_by(warehouse_id: warehouse.id, product_id: product.id)
+    stock_count = Stock.where(warehouse_id: warehouse.id, product_id: product.id).count
 
-    assert_equal stock.quantity, 15
+    assert_equal stock_count, 10
   end
 
   test 'Successfully update new stock in warehouse' do
@@ -24,9 +24,9 @@ class UpdateStocksTest < ActionDispatch::IntegrationTest
 
     assert_equal 200, status
 
-    stock = Stock.find_by(warehouse_id: warehouse.id, product_id: product.id)
+    stock_count = Stock.where(warehouse_id: warehouse.id, product_id: product.id).count
 
-    assert_equal stock.quantity, 5
+    assert_equal stock_count, 5
   end
 
   test 'gracefully return for not found warehouse' do
@@ -48,4 +48,15 @@ class UpdateStocksTest < ActionDispatch::IntegrationTest
     assert_equal 412, status
     assert_equal 'product 000000001 does not exist', JSON.parse(body)['error']
   end
+
+  test 'gracefully return for non integer quantity' do
+    warehouse = Warehouse.find_by(code: 'ABC123')
+    product = Product.find_by(code: 'ABC123')
+
+    put "/stocks/#{warehouse.id}/#{product.id}/five"
+
+    assert_equal 400, status
+    assert_equal 'Quantity must be an integer', JSON.parse(body)['error']
+  end
+
 end

--- a/test/fixtures/stocks.yml
+++ b/test/fixtures/stocks.yml
@@ -1,11 +1,37 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  quantity: 10
   warehouse: one
   product: one
 
 two:
-  quantity: 8
   warehouse: two
   product: two
+
+three: 
+  warehouse: one
+  product: two
+
+reserved_one:
+  warehouse: one
+  product: one
+  reserved: true
+  order: two
+
+reserved_two:
+  warehouse: one
+  product: one
+  reserved: true 
+  order: two
+
+reserved_three:
+  warehouse: one
+  product: one
+  reserved: true
+  order: two
+
+reserved_four:
+  warehouse: one
+  product: one
+  reserved: true
+  order: three


### PR DESCRIPTION
Refactor so each physical item of stock has its own stock record.

Upon looking at the spec again ahead of implementing orders I saw that I'd misunderstood and that each individual item in the warehouse was to have its own stock record and that this made sense from the point of view of stock reservation logic. 

This refactor puts that in place. The contract for the stock level endpoint also changed to be a dict with warehouse codes as keys as opposed to a list of warehouse entries. This was easier to construct and also made as much sense from the perspective of interpreting the output data structure. 

I opted to edit the existing migration instead of creating a new one to change the stocks table. I did this to keep things clearer and because this app hasn't been deployed yet. Were it a system with actual data in the DB, obviously, this wouldn't be an option. 