### PR TITLE
Order placement and stock intake in active jobs 

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -23,11 +23,8 @@ class OrdersController < ApplicationController
       return render json: { error: 'Quantity must be an integer' }, status: 400
     end
 
-    if OrderCreator.call(warehouse_id, product_id, quantity)
-      render json: :success
-    else
-      render json: { error: 'The ordered product has fewer items in storage than has been ordered. Order not placed.' },
-             status: 202
-    end
+    job_id = PlaceOrderJob.perform_later(warehouse_id, product_id, quantity)
+
+    render json: { job_id: }
   end
 end

--- a/app/controllers/stocks_controller.rb
+++ b/app/controllers/stocks_controller.rb
@@ -36,8 +36,8 @@ class StocksController < ApplicationController
     rescue ArgumentError
       return render json: { error: 'Quantity must be an integer' }, status: 400
     end
-    Stock.intake(warehouse_id, product_id, quantity)
-    render json: :success
+    job_id = StockIntakeJob.perform_later(warehouse_id, product_id, quantity)
+    render json: { job_id: }
   end
 
   private

--- a/app/jobs/place_order_job.rb
+++ b/app/jobs/place_order_job.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class PlaceOrderJob < ApplicationJob
+  def perform(warehouse_id, product_id, quantity)
+    OrderCreator.call(warehouse_id, product_id, quantity)
+  end
+end

--- a/app/jobs/stock_intake_job.rb
+++ b/app/jobs/stock_intake_job.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class StockIntakeJob < ApplicationJob
+  def perform(warehouse_id, product_id, quantity)
+    Stock.intake(warehouse_id, product_id, quantity)
+  end
+end

--- a/app/services/order_creator.rb
+++ b/app/services/order_creator.rb
@@ -28,7 +28,6 @@ class OrderCreator
   end
 
   def create_order
-    # @todo - wrap this in a transaction and active job to avoid race conditins
     @order = Order.create(warehouse_id: @warehouse_id, product_id: @product_id, quantity: @quantity)
     allocate_stocks
   end

--- a/docs/api/order.md
+++ b/docs/api/order.md
@@ -8,11 +8,10 @@
 
 |type|code|description|
 |-|-|-|
-|success| 200||
+|success| 200| `{ job_id: '1232131' }`|
 |server error| 500||
 |warehouse not found|412| The spefified warehouse does not exist|
-|product not found| 412 | The ordered product does not exist in the inventory for the speficied warehouse. Takes precidence over insufficient stock.|
-|insufficient stock| 202 | The ordered product has fewer items in storage than has been ordered. Order not placed.|
+|product not found| 412 | The ordered product does not exist in the inventory for the speficied warehouse.|
 |Non integer quantitiy| 400| Quantity must be an integer|
 
 ## Dispatch

--- a/docs/api/stocks.md
+++ b/docs/api/stocks.md
@@ -9,7 +9,7 @@
 
 |type|code|description|
 |-|-|-|
-|success| 200||
+|success| 200|`{ job_id: '1232131' }`|
 |server error| 500||
 |warehouse not found|412| The spefified warehouse does not exist|
 |product not found| 412 | The ordered product does not exist in the inventory for the speficied warehouse.|

--- a/test/concerns/stock_intake_test.rb
+++ b/test/concerns/stock_intake_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class StockLevelsDummy < ActiveRecord::Base
+  self.table_name = 'stocks'
+
+  include StockLevelsConcern
+end
+
+class StockIntakeTest < ActiveSupport::TestCase
+  test 'add stock to warehouse' do
+    warehouse = Warehouse.find_by(code: 'ABC123')
+    product = Product.find_by(code: 'ABC123')
+
+    StockLevelsDummy.intake(warehouse.id, product.id, 5)
+
+    stock_count = Stock.where(warehouse_id: warehouse.id, product_id: product.id).count
+
+    assert_equal stock_count, 11
+  end
+
+  test 'add new stock to warehouse' do
+    warehouse = Warehouse.find_by(code: 'ABC123')
+    product = Product.find_by(code: 'GHI789')
+
+    StockLevelsDummy.intake(warehouse.id, product.id, 5)
+
+    stock_count = Stock.where(warehouse_id: warehouse.id, product_id: product.id).count
+
+    assert_equal stock_count, 5
+  end
+end

--- a/test/concerns/stock_levels_test.rb
+++ b/test/concerns/stock_levels_test.rb
@@ -16,7 +16,8 @@ class StockLevelsTest < ActiveSupport::TestCase
                  {
                    'ABC123' => [{ product_code: 'DEF456', total: 1, unreserved: 1, reserved: 0 },
                                 { product_code: 'ABC123', total: 6, unreserved: 2,
-                                  reserved: 4 }], 'XYZ789' => [{ product_code: 'DEF456', total: 1, unreserved: 1, reserved: 0 }]
+                                  reserved: 4 }],
+                   'XYZ789' => [{ product_code: 'DEF456', total: 1, unreserved: 1, reserved: 0 }]
                  }
   end
 end

--- a/test/controllers/orders/create_order_controller_test.rb
+++ b/test/controllers/orders/create_order_controller_test.rb
@@ -11,17 +11,8 @@ class CreateOrderControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal 200, status
 
-  end
-
-  test 'order too many items' do
-    warehouse = Warehouse.find_by(code: 'ABC123')
-    product = Product.find_by(code: 'ABC123')
-
-    put "/orders/#{warehouse.id}/#{product.id}/3"
-
-    assert_equal 202, status
-    assert_equal 'The ordered product has fewer items in storage than has been ordered. Order not placed.', JSON.parse(body)['error']
-
+    assert_includes JSON.parse(body).keys, 'job_id'
+    assert_not_nil JSON.parse(body)['job_id']
   end
 
   test 'non numeric quantity' do
@@ -53,5 +44,4 @@ class CreateOrderControllerTest < ActionDispatch::IntegrationTest
     assert_equal 412, status
     assert_equal 'product 000000001 does not exist', JSON.parse(body)['error']
   end
-
 end

--- a/test/controllers/stocks/stock_levels_controller_test.rb
+++ b/test/controllers/stocks/stock_levels_controller_test.rb
@@ -11,7 +11,8 @@ class StockLevelsControllerTest < ActionDispatch::IntegrationTest
                  {
                    'ABC123' => [{ product_code: 'DEF456', total: 1, unreserved: 1, reserved: 0 },
                                 { product_code: 'ABC123', total: 6, unreserved: 2,
-                                  reserved: 4 }], 'XYZ789' => [{ product_code: 'DEF456', total: 1, unreserved: 1, reserved: 0 }]
+                                  reserved: 4 }],
+                   'XYZ789' => [{ product_code: 'DEF456', total: 1, unreserved: 1, reserved: 0 }]
                  }.to_json
   end
 end

--- a/test/controllers/stocks/update_stocks_test.rb
+++ b/test/controllers/stocks/update_stocks_test.rb
@@ -11,22 +11,8 @@ class UpdateStocksTest < ActionDispatch::IntegrationTest
 
     assert_equal 200, status
 
-    stock_count = Stock.where(warehouse_id: warehouse.id, product_id: product.id).count
-
-    assert_equal stock_count, 11
-  end
-
-  test 'Successfully update new stock in warehouse' do
-    warehouse = Warehouse.find_by(code: 'ABC123')
-    product = Product.find_by(code: 'GHI789')
-
-    put "/stocks/#{warehouse.id}/#{product.id}/5"
-
-    assert_equal 200, status
-
-    stock_count = Stock.where(warehouse_id: warehouse.id, product_id: product.id).count
-
-    assert_equal stock_count, 5
+    assert_includes JSON.parse(body).keys, 'job_id'
+    assert_not_nil JSON.parse(body)['job_id']
   end
 
   test 'gracefully return for not found warehouse' do
@@ -58,5 +44,4 @@ class UpdateStocksTest < ActionDispatch::IntegrationTest
     assert_equal 400, status
     assert_equal 'Quantity must be an integer', JSON.parse(body)['error']
   end
-
 end

--- a/test/services/order_creator_test.rb
+++ b/test/services/order_creator_test.rb
@@ -3,7 +3,6 @@
 require 'test_helper'
 
 class OrderCreatorTest < ActiveSupport::TestCase
-
   warehouse = Warehouse.find_by(code: 'ABC123')
   product = Product.find_by(code: 'ABC123')
   test 'correctly creates order and allocates stock' do
@@ -16,9 +15,9 @@ class OrderCreatorTest < ActiveSupport::TestCase
     assert_equal order.quantity, 2
 
     assert_equal Stock.where(warehouse_id: warehouse.id, product_id: product.id, reserved: true).count, 6
-    assert_equal Stock.where(warehouse_id: warehouse.id, product_id: product.id, reserved: true, order_id: order_id).count, 2
+    assert_equal Stock.where(warehouse_id: warehouse.id, product_id: product.id, reserved: true, order_id:).count,
+                 2
     assert_equal Stock.where(warehouse_id: warehouse.id, product_id: product.id, reserved: false).count, 0
-
   end
 
   test 'returns false when not enough stock available' do
@@ -28,5 +27,4 @@ class OrderCreatorTest < ActiveSupport::TestCase
     assert_equal Stock.where(warehouse_id: warehouse.id, product_id: product.id, reserved: true).count, 4
     assert_equal Stock.where(warehouse_id: warehouse.id, product_id: product.id, reserved: false).count, 2
   end
-
 end


### PR DESCRIPTION
To make the system robust for high traffic and horizontal scaling. 

Making the DB writes asynchronous posed a design choice regarding feedback for the user. There is a chance an order can't be placed due to insufficient stock. However, checking, returning a success and then making the creation async would create a race condition. 

I decided that returning the job number was an adequate compromise for MVP. This way the order success is traceable.

There are also some unrelated linting fixes in this PR.